### PR TITLE
Revert SECURITY.md email to official obfuscated form

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ If you believe you have found a security vulnerability in any GitHub-owned repos
 
 **Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
 
-Instead, please send an email to <opensource-security@github.com>.
+Instead, please send an email to opensource-security[@]github.com.
 
 Please include as much of the information listed below as you can to help us better understand and resolve the issue:
 


### PR DESCRIPTION
Reverts the security email to `opensource-security[@]github.com` to match the [official template](https://github.com/github/open-source-releases/blob/main/templates/SECURITY.md) and avoid the OSPO scanner sensitive content flag.